### PR TITLE
fix: prevent toast overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,14 @@
   const esc=s=>(s||'').replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
   const fmt=v=>v??'';
   const clsFor=(done,total)=> total===0||done===0?'gray':(done<total?'yellow':'green');
-  const toast=msg=>{ const t=$('#toast'); t.textContent=msg; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'),1200); };
+  let toastTimer;
+  const toast=msg=>{
+    const t=$('#toast');
+    t.textContent=msg;
+    t.classList.add('show');
+    clearTimeout(toastTimer);
+    toastTimer=setTimeout(()=>t.classList.remove('show'),1200);
+  };
   const openOverlay=()=>$('#ov').classList.add('open');
   const closeOverlay=()=>$('#ov').classList.remove('open');
 


### PR DESCRIPTION
## Summary
- ensure toast display resets timer before showing a new message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72ef2f46c8331afaf93916dc2ed38